### PR TITLE
Add ability to inject DeserializerBuilder

### DIFF
--- a/EPS.Extensions.YamlMarkdown/EPS.Extensions.YamlMarkdown.csproj
+++ b/EPS.Extensions.YamlMarkdown/EPS.Extensions.YamlMarkdown.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
-        <PackageVersion>0.6.0</PackageVersion>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <PackageVersion>0.7.0</PackageVersion>
         <Title>YamlMarkdown - Markdown with YAML front-matter</Title>
         <Description>If you've ever worked on an app and you needed quick access to something that can read a Markdown file with YAML front-matter, then this is your library. Using YamlDotNet and Markdig, we take your YAML object, serialize it for you, and give you Markdown and parsed HTML for your page data. </Description>
         <PackageProjectUrl>https://github.com/endpointsystems/EPS.Extensions</PackageProjectUrl>
@@ -15,9 +15,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Html2Markdown" Version="3.2.1.341" />
-      <PackageReference Include="Markdig" Version="0.18.0" />
-      <PackageReference Include="YamlDotNet" Version="8.0.0" />
+      <PackageReference Include="Html2Markdown" Version="3.3.1.407" />
+      <PackageReference Include="Markdig" Version="0.18.2" />
+      <PackageReference Include="YamlDotNet" Version="8.1.0" />
     </ItemGroup>
 
 </Project>

--- a/EPS.Extensions.YamlMarkdown/YamlMarkdown.cs
+++ b/EPS.Extensions.YamlMarkdown/YamlMarkdown.cs
@@ -13,35 +13,32 @@ namespace EPS.Extensions.YamlMarkdown
     /// Deserialize the YAML and return the Markdown and HTML.
     /// </summary>
     /// <typeparam name="T">The data type to deserialize from the YAML.</typeparam>
-    public class YamlMarkdown<T> where T: new()
+    public class YamlMarkdown<T> where T : new()
     {
         private IDeserializer yaml;
         private ISerializer yamlSerializer;
 
-        public YamlMarkdown()
+        public YamlMarkdown(IDeserializer deserializerBuilder = null)
         {
-            init();
+            init(deserializerBuilder);
         }
 
-        public YamlMarkdown(string filePath)
+        public YamlMarkdown(string filePath, IDeserializer deserializerBuilder = null) : this(deserializerBuilder)
         {
-            FileName = Path.GetFileNameWithoutExtension(filePath);
-            init();
             Parse(filePath);
         }
 
-        public YamlMarkdown(TextReader reader)
+        public YamlMarkdown(TextReader reader, IDeserializer deserializerBuilder = null) : this(deserializerBuilder)
         {
-            init();
             Parse(reader);
         }
 
-        private void init()
+        private void init(IDeserializer deserializerBuilder = null)
         {
-            yaml = new DeserializerBuilder()
-                .Build();
+            yaml = deserializerBuilder != null ? deserializerBuilder : new DeserializerBuilder().Build();
             yamlSerializer = new Serializer();
         }
+
         /// <summary>
         /// Parses a file from the file system.
         /// </summary>
@@ -100,7 +97,7 @@ namespace EPS.Extensions.YamlMarkdown
             {
                 throw new SyntaxErrorException("An exception occured parsing the YAML. Check the dash " +
                                                "separators and the YAML syntax before trying again. Further " +
-                                               "details can be found in the original inner exception.",se);
+                                               "details can be found in the original inner exception.", se);
             }
             catch (YamlException ye)
             {
@@ -130,12 +127,12 @@ namespace EPS.Extensions.YamlMarkdown
             sb.Append(y);
             sb.AppendLine("---");
             sb.Append(markdown);
-            File.WriteAllText(path,sb.ToString());
+            File.WriteAllText(path, sb.ToString());
         }
 
         public void Save(string markdown, string path)
         {
-            Save(DataObject,markdown,path);
+            Save(DataObject, markdown, path);
         }
 
 
@@ -170,7 +167,7 @@ namespace EPS.Extensions.YamlMarkdown
         /// Gets the parsed Markdown from the YAML/Markdown file.
         /// </summary>
         // ReSharper disable once UnusedAutoPropertyAccessor.Global
-        public string Html{get;set;}
+        public string Html { get; set; }
 
     }
 }

--- a/test/EPS.Extensions.Test/EPS.Extensions.Test.csproj
+++ b/test/EPS.Extensions.Test/EPS.Extensions.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>
@@ -13,10 +13,17 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
         <PackageReference Include="xunit" Version="2.4.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+        <PackageReference Include="YamlDotNet" Version="8.1.0" />
+
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\EPS.Extensions.YamlMarkdown\EPS.Extensions.YamlMarkdown.csproj" />
+        <ProjectReference Include="..\..\EPS.Extensions.YamlMarkdown\EPS.Extensions.YamlMarkdown.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <Content Include="assets\*.*">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
 </Project>

--- a/test/EPS.Extensions.Test/assets/in.md
+++ b/test/EPS.Extensions.Test/assets/in.md
@@ -1,0 +1,24 @@
+---
+Id: 123
+dateModified: 1/1/2001
+datePublished: 1/1/2001
+headline: "Headline text"
+ids:
+    - 1
+    - 2
+slug: "Slug text"
+description: "Description text"
+image: 
+    - "Image 1 text"
+    - "Image 2 text"
+imageId: "Image id text"
+body: "Body text"
+categories:
+    - "Category 1 text"
+    - "Category 2 text"
+author: "Author text"
+---
+
+# Headline 1
+
+Here's some *text* to parse.

--- a/test/EPS.Extensions.Test/assets/in2.md
+++ b/test/EPS.Extensions.Test/assets/in2.md
@@ -1,0 +1,25 @@
+---
+Id: 123
+unmatchedProperty: "unmatchedProperty text"
+dateModified: 1/1/2001
+datePublished: 1/1/2001
+headline: "Headline text"
+ids:
+    - 1
+    - 2
+slug: "Slug text"
+description: "Description text"
+image: 
+    - "Image 1 text"
+    - "Image 2 text"
+imageId: "Image id text"
+body: "Body text"
+categories:
+    - "Category 1 text"
+    - "Category 2 text"
+author: "Author text"
+---
+
+# Headline 1
+
+Here's some *text* to parse.

--- a/test/EPS.Extensions.Test/yaml_test.cs
+++ b/test/EPS.Extensions.Test/yaml_test.cs
@@ -4,13 +4,14 @@ using EPS.Extensions.YamlMarkdown;
 using Machine.Specifications;
 using Machine.Specifications.Model;
 using Xunit;
+using YamlDotNet.Serialization;
 
 namespace EPS.Extensions.Test
 {
     public class yaml_test
     {
-        private static string inPath = "~/test/in/in.md";
-        private static string outPath = "~/test/out/out.md";
+        private static string inPath = "assets/in.md";
+        private static string outPath = "assets/out.md";
 
         private static YamlMarkdown<Article> yamlArticle;
         private static Article article;
@@ -25,6 +26,16 @@ namespace EPS.Extensions.Test
         {
             var markup = yamlArticle.Markdown;
             yamlArticle.Save(article, markup, outPath);
+        };
+
+        private It should_parse_with_unmatched_properties = () =>
+        {
+            yamlArticle = new YamlMarkdown<Article>(
+                new DeserializerBuilder()
+                    .IgnoreUnmatchedProperties()
+                    .Build()
+            );
+            article = yamlArticle.Parse(inPath);
         };
     }
 }


### PR DESCRIPTION
I needed the ability to parse random .md files that contain various front matter properties.  By default DeserializerBuilder throws an exception if the .md file contains properties that are not in the desired .NET type.

We could just enable this by default by calling IgnoreUnmatchedProperties on the builder directly in the Parse method, but I figured I will need to set other DeserializerBuilder properties in the future and didn't want to have all those also be the defaults.  And didn't want to get into passing "Options" into the Parse method.